### PR TITLE
FIX: add missing item type 'PlaylistsFolder'

### DIFF
--- a/custom_components/jellyfin/media_source.py
+++ b/custom_components/jellyfin/media_source.py
@@ -148,6 +148,7 @@ def Type2Mediatype(type):
         "Folder": MEDIA_CLASS_DIRECTORY,
         "CollectionFolder": MEDIA_CLASS_DIRECTORY,
         "Playlist": MEDIA_CLASS_DIRECTORY,
+        "PlaylistsFolder": MEDIA_CLASS_DIRECTORY,
         "MusicArtist": MEDIA_TYPE_ARTIST,
         "MusicAlbum": MEDIA_TYPE_ALBUM,
     }
@@ -164,6 +165,7 @@ def Type2Mediaclass(type):
         "Folder": MEDIA_CLASS_DIRECTORY,
         "CollectionFolder": MEDIA_CLASS_DIRECTORY,
         "Playlist": MEDIA_CLASS_DIRECTORY,
+        "PlaylistsFolder": MEDIA_CLASS_DIRECTORY,
         "MusicArtist": MEDIA_CLASS_ARTIST,
         "MusicAlbum": MEDIA_CLASS_ALBUM,
         "Audio": MEDIA_CLASS_TRACK,
@@ -181,6 +183,7 @@ def IsPlayable(type, canPlayList):
         "Folder": False,
         "CollectionFolder": False,
         "Playlist": canPlayList,
+        "PlaylistsFolder": False,
         "MusicArtist": canPlayList,
         "MusicAlbum": canPlayList,
         "Audio": True,


### PR DESCRIPTION
Only tested on Jellyfin Version: 10.7.5

When you have at least 1 playlist it creates a top-level folder for all playlists with a type of `PlaylistsFolder`.

The output of item dump for the playlist folder

```json
{
  "Name": "Playlists",
  "ServerId": "f7df75e0e00d4ba887b85d79f0a4fd3c",
  "Id": "1071671e7bffa0532e930debee501d2e",
  "ChannelId": "None",
  "IsFolder": true,
  "Type": "PlaylistsFolder",
  "UserData": {
    "PlaybackPositionTicks": 0,
    "PlayCount": 0,
    "IsFavorite": false,
    "Played": false,
    "Key": "1071671e-7bff-a053-2e93-0debee501d2e"
  },
  "CollectionType": "playlists",
  "ImageTags": {},
  "BackdropImageTags": [],
  "ImageBlurHashes": {},
  "LocationType": "FileSystem"
}
```